### PR TITLE
Alter strings for use with pycryptodome

### DIFF
--- a/decrypt-conf.py
+++ b/decrypt-conf.py
@@ -3,8 +3,8 @@ import struct
 from Crypto.Cipher import AES
 import sys
 
-KEY = "iwp2390x-e]57kx&#@*(ca,sfkf!eu+$"
-IV = "fiw;opdd40382,*&"
+KEY = b'iwp2390x-e]57kx&#@*(ca,sfkf!eu+$'
+IV = b'fiw;opdd40382,*&'
 OUT = '%s.txt'
 
 def decrypt(settings):


### PR DESCRIPTION
pycrypto at https://github.com/sfbahr/PyCrypto-Wheels hasn't been updated in three years and won't install on windows
pycryptodome is a "drop in replacement" for pycrypto, but throws errors on this script.
changing the KEY and IV strings to b'<string>' was listed as a solution here: https://github.com/Legrandin/pycryptodome/issues/35