### PR TITLE
Add a method to automatically get admin password

### DIFF
--- a/CredentialFetch.py
+++ b/CredentialFetch.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+import requests
+from requests.auth import HTTPDigestAuth
+
+
+url = input("What's your default gateway? (Leave blank to default to 192.168.0.1, reccomended)\n")
+if url == "":
+    print("Empty, defaulting to 192.168.0.1")
+    url = 'http://192.168.0.1/dumpmdm.txt'
+
+password = input("What is your password? (Used to access the wifi network):\n")
+if password != "":
+    result = requests.get(url, auth=HTTPDigestAuth("optus", password)).text
+else:
+    raise ValueError("Password Cannot Be Empty")
+
+import re
+reg = "(?<=&lt;AdminPassword&gt;)[^<>]*(?=&lt;/AdminPassword&gt;)"
+match = re.search(reg, result)
+print("Admin Login is:\n admin:" + str(match.group()))


### PR DESCRIPTION
This may be useful as it could allow non-technical users to grab their admin password, plus makes it less of an eyesore by having to look thru the dump manually.
This has been tested with the 10.108_F@ST3864V3HP_Optus software version, and 10.70 bootloader, but may need further testing with others routers.

This runs with python 3.9 and could probably be compiled to a portable executable if needed for ease of access.

Thanks, GhostDog